### PR TITLE
Added ability to get an Alpha-2 code from a country name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,23 @@ exports.getNames = function(lang) {
 	}
 };
 
+exports.getAlpha2Code = function(name, lang) {
+	"use strict";
+	try {
+		var p,
+		    codenames = langs[lang.toLowerCase()].i18n();
+		for (p in codenames) {
+			if (codenames.hasOwnProperty(p)) {
+				if (codenames[p].toLowerCase() === name.toLowerCase()) {
+					return p;
+				}
+			}
+		}
+		return undefined;
+	} catch (err) {
+		return undefined;
+	}
+};
 /*
  * @return hash (alpha-2 => alpha-3)
  */

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -91,6 +91,14 @@ describe("i18n for iso 3166-1", function () {
 	});
 	describe("en", function () {
 		var lang = "en";
+		describe("get Alpha-2 code", function() {
+			it("nameToAlpha2 United States => US", function() {
+				assert.equal(i18niso.getAlpha2Code("United States", lang), "US");
+			});
+			it("nameToAlpha2 Brazil => BR", function() {
+				assert.equal(i18niso.getAlpha2Code("Brazil", lang), "BR");
+			});
+		});
 		describe("get name", function () {
 			it("for de", function () {
 				assert.equal(i18niso.getName("de", lang), "Germany");


### PR DESCRIPTION
I needed to do this reverse lookup to get a code from a name, since the data is already here, it seemed logical to add this function.

The search is implemented as a simple traverse. There are probably a few ways to make this more performant but the list is not that long so this should work for most scenarios. 