### PR TITLE
Remove "Province of China" from Taiwan listing

### DIFF
--- a/en.js
+++ b/en.js
@@ -204,7 +204,7 @@ var i18n = {
 	"SE": "Sweden",
 	"CH": "Switzerland",
 	"SY": "Syrian Arab Republic",
-	"TW": "Taiwan, Province of China",
+	"TW": "Taiwan",
 	"TJ": "Tajikistan",
 	"TZ": "Tanzania, United Republic of",
 	"TH": "Thailand",

--- a/es.js
+++ b/es.js
@@ -204,7 +204,7 @@ var i18n = {
 	"SE": "Suecia",
 	"CH": "Suiza",
 	"SY": "República Árabe Siria",
-	"TW": "Taiwán (Provincia de China)",
+	"TW": "Taiwán",
 	"TJ": "Tayikistán",
 	"TZ": "Tanzania, República Unida de",
 	"TH": "Tailandia",


### PR DESCRIPTION
We received an annoyed message from a user about this - there's no need to declare ownership in any country listing, regardless.