### PR TITLE
mistake in ISO for Swedish. Should be SE

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ console.log(countries.getNames("en")); // { 'AF': 'Afghanistan', 'AL': 'Albania'
 * `pl`: polish
 * `pt`: portuguese
 * `ru`: russian
-* `sv`: swedish
+* `se`: swedish
 * `tr`: turkish
 * `uk`: ukrainian
 * `zh`: Chinese


### PR DESCRIPTION
The ISO format for Sweden is SE. Currently it is marked as SV.