### PR TITLE
fix french translation of country France

### DIFF
--- a/langs/fr.json
+++ b/langs/fr.json
@@ -71,7 +71,7 @@
   "FO": "Îles Féroé",
   "FJ": "Fidji",
   "FI": "Finlande",
-  "FR": "France Métropolitaine",
+  "FR": "France",
   "GF": "Guyane française",
   "PF": "Polynésie française",
   "TF": "Terres australes françaises",

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -285,6 +285,14 @@ describe("i18n for iso 3166-1", function () {
         });
       });
     });
+    describe("fr", function () {
+      var lang = "fr";
+      describe("get name", function () {
+        it("for fr => France", function () {
+          assert.equal(i18niso.getName("fr", lang), "France");
+        });
+      });
+    });
     describe("unsupported language", function () {
       var lang = "unsupported";
       it("get name", function () {


### PR DESCRIPTION
I think the french translation of the  ISO 3166-2 code is not correct. Today it is "France métropolitaine" but it should simply be "France".

https://www.iso.org/obp/ui/fr/#iso:code:3166:FR
https://fr.wikipedia.org/wiki/France