### PR TITLE
Remove the padStart and replace for a simple slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ i18n for ISO 3166-1 country codes. We support Alpha-2, Alpha-3 and Numeric codes
 
 Install it using npm: `npm install i18n-iso-countries`
 
-This library requires that [String#padStart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart) is available. If your environment does not support this method, you will need to [polyfill](https://www.npmjs.com/package/core-js) it.
-
-If used in a browser environment, you will need to manually install the local you wish to support.
-
 ```javascript
 var countries = require("i18n-iso-countries");
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ codes.forEach(function(codeInformation) {
 });
 
 function formatNumericCode(code) {
-  return String(code).padStart(3, "0");
+  return String('000'+(code ? code : '')).slice(-3);
 }
 
 function registerLocale(localeData) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-iso-countries",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "devDependencies": {
     "assert-plus": "1.0.0",
     "mocha": "4.0.1",
-    "core-js": "2.5.1",
     "jshint": "2.9.5",
     "madge": "2.2.0",
     "npmedge": "0.2.2",

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -1,5 +1,3 @@
-require('core-js/modules/es7.string.pad-start');
-
 var assert = require("assert-plus"),
   i18niso = require("../");
 


### PR DESCRIPTION
This commit is going to improve the range of node versions for this library without polyfill.

Replace the padStart from String, this is available only for node 8, and changed it to a simple slice.