### PR TITLE
Fix is valid country code

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,5 +233,6 @@ exports.langs = function() {
  * @return Boolean
  */
 exports.isValid = function(code) {
-  return this.toAlpha3(code) !== undefined;
+  return alpha3.hasOwnProperty(code) || alpha2.hasOwnProperty(code) ||
+    numeric.hasOwnProperty(code);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-iso-countries",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "i18n for ISO 3166-1 country codes",
   "typings": "index.d.js",
   "keywords": [

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -159,6 +159,9 @@ describe("i18n for iso 3166-1", function () {
     it("isValid 999 => false", function() {
       assert.equal(i18niso.isValid(999), false);
     });
+    it("isValid ... => false", function() {
+      assert.equal(i18niso.isValid('...'), false);
+    });
   });
   describe("completeness", function () {
     i18niso.langs().forEach(function(lang) {


### PR DESCRIPTION
fixed isValid function for the input '...'
I think it is more bulletproof to check in the alpha2, alpha3 and numeric object than use toAlpha3 code which looks broken