### PR TITLE
Fix capitalisation for United Arab Emirates

### DIFF
--- a/langs/fr.json
+++ b/langs/fr.json
@@ -222,7 +222,7 @@
     "TV": "Tuvalu",
     "UG": "Ouganda",
     "UA": "Ukraine",
-    "AE": "Émirats arabes unis",
+    "AE": "Émirats Arabes Unis",
     "GB": "Royaume-Uni",
     "US": "États-Unis d'Amérique",
     "UM": "Îles mineures éloignées des États-Unis",


### PR DESCRIPTION
In French, the capitalisation for United Arab Emirates was missing.