### PR TITLE
Back to previous behaviour: isValid is case-insentive

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,11 @@ exports.langs = function() {
  * @return Boolean
  */
 exports.isValid = function(code) {
-  return alpha3.hasOwnProperty(code) || alpha2.hasOwnProperty(code) ||
-    numeric.hasOwnProperty(code);
+  if (!code) {
+    return false;
+  }
+
+  const coerced = code.toString().toUpperCase();
+  return alpha3.hasOwnProperty(coerced) || alpha2.hasOwnProperty(coerced) ||
+    numeric.hasOwnProperty(coerced);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-iso-countries",
-  "version": "3.6.3",
+  "version": "3.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,10 +16,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "align-text": {
@@ -28,9 +28,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -99,8 +99,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -115,13 +115,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -130,7 +130,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -141,7 +141,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "asn1": {
@@ -192,8 +192,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babylon": {
@@ -215,7 +215,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "block-stream": {
@@ -224,7 +224,7 @@
       "integrity": "sha1-kIirWuHoYfTYGxdrSoBGCAcD3u0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "boom": {
@@ -233,7 +233,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -242,7 +242,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -272,8 +272,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -282,11 +282,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -322,7 +322,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.2"
+        "glob": "^7.1.1"
       },
       "dependencies": {
         "glob": {
@@ -331,12 +331,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -347,7 +347,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -363,8 +363,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -395,7 +395,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -404,7 +404,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "commondir": {
@@ -425,8 +425,8 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5",
-        "proto-list": "1.2.4"
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "console-browserify": {
@@ -435,7 +435,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -462,7 +462,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -471,7 +471,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -482,7 +482,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -537,10 +537,10 @@
       "integrity": "sha1-koRk1vknNgfT9muaV+JZ5jVmd1U=",
       "dev": true,
       "requires": {
-        "commander": "2.9.0",
-        "debug": "2.2.0",
-        "filing-cabinet": "1.12.0",
-        "precinct": "3.8.0"
+        "commander": "^2.6.0",
+        "debug": "^2.2.0",
+        "filing-cabinet": "^1.9.0",
+        "precinct": "^3.8.0"
       }
     },
     "detective-amd": {
@@ -549,10 +549,10 @@
       "integrity": "sha1-XrDfTvXBipQDOwfa8TbbzV/HXNU=",
       "dev": true,
       "requires": {
-        "ast-module-types": "2.3.2",
-        "escodegen": "1.8.1",
-        "get-amd-module-type": "2.0.5",
-        "node-source-walk": "3.3.0"
+        "ast-module-types": "^2.3.1",
+        "escodegen": "^1.8.0",
+        "get-amd-module-type": "^2.0.4",
+        "node-source-walk": "^3.0.0"
       }
     },
     "detective-cjs": {
@@ -561,8 +561,8 @@
       "integrity": "sha1-3OTJMCzcpS5ri/04d8qT9ixczAM=",
       "dev": true,
       "requires": {
-        "ast-module-types": "2.3.2",
-        "node-source-walk": "3.3.0"
+        "ast-module-types": "^2.3.2",
+        "node-source-walk": "^3.0.0"
       }
     },
     "detective-es6": {
@@ -571,7 +571,7 @@
       "integrity": "sha1-a5s71Uf9jyH4lQL2JuRe0qMnb9w=",
       "dev": true,
       "requires": {
-        "node-source-walk": "3.3.0"
+        "node-source-walk": "^3.3.0"
       }
     },
     "detective-less": {
@@ -580,9 +580,9 @@
       "integrity": "sha1-Qmx4yatuMnW/ZsyRq6wAU7tFLX0=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "gonzales-pe": "3.4.7",
-        "node-source-walk": "3.3.0"
+        "debug": "~2.2.0",
+        "gonzales-pe": "^3.4.4",
+        "node-source-walk": "^3.2.0"
       }
     },
     "detective-sass": {
@@ -591,9 +591,9 @@
       "integrity": "sha1-BWYKoblc/Yf1dGQ7+s4+iiaBEqE=",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "gonzales-pe": "3.4.7",
-        "node-source-walk": "3.3.0"
+        "debug": "^3.1.0",
+        "gonzales-pe": "^3.4.4",
+        "node-source-walk": "^3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -619,9 +619,9 @@
       "integrity": "sha1-dDJGoN01jZ2R/0ElQX9qd/vPJw8=",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "gonzales-pe": "3.4.7",
-        "node-source-walk": "3.3.0"
+        "debug": "^3.1.0",
+        "gonzales-pe": "^3.4.4",
+        "node-source-walk": "^3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -664,7 +664,7 @@
           "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.0.0"
           }
         },
         "node-source-walk": {
@@ -673,7 +673,7 @@
           "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
           "dev": true,
           "requires": {
-            "babylon": "6.8.4"
+            "babylon": "~6.8.1"
           }
         },
         "typescript": {
@@ -696,8 +696,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -726,7 +726,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -735,8 +735,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "ecc-jsbn": {
@@ -746,7 +746,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "enhanced-resolve": {
@@ -755,10 +755,10 @@
       "integrity": "sha1-3xTAa1/F7sreEJTJxaErSz7cC2I=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.5"
       }
     },
     "entities": {
@@ -773,7 +773,7 @@
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~0.0.0"
       }
     },
     "escape-string-regexp": {
@@ -788,11 +788,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       }
     },
     "esprima": {
@@ -861,19 +861,19 @@
       "integrity": "sha1-b7k/2WjoO+3xtCmPKCNqiq/ffXg=",
       "dev": true,
       "requires": {
-        "app-module-path": "1.1.0",
-        "commander": "2.9.0",
-        "debug": "2.2.0",
-        "enhanced-resolve": "3.0.3",
-        "is-relative-path": "1.0.2",
-        "module-definition": "2.2.4",
-        "module-lookup-amd": "4.0.5",
-        "object-assign": "4.1.1",
-        "resolve": "1.1.7",
-        "resolve-dependency-path": "1.0.2",
-        "sass-lookup": "1.1.0",
-        "stylus-lookup": "1.0.2",
-        "typescript": "2.6.2"
+        "app-module-path": "^1.1.0",
+        "commander": "^2.8.1",
+        "debug": "^2.2.0",
+        "enhanced-resolve": "~3.0.3",
+        "is-relative-path": "^1.0.1",
+        "module-definition": "^2.2.4",
+        "module-lookup-amd": "^4.0.2",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.7",
+        "resolve-dependency-path": "^1.0.2",
+        "sass-lookup": "^1.1.0",
+        "stylus-lookup": "^1.0.1",
+        "typescript": "^2.4.2"
       }
     },
     "find": {
@@ -882,7 +882,7 @@
       "integrity": "sha1-DSGLXUjDQkGT9kzqWdOJ+NqnHQE=",
       "dev": true,
       "requires": {
-        "traverse-chain": "0.1.0"
+        "traverse-chain": "~0.1.0"
       }
     },
     "forever-agent": {
@@ -897,9 +897,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -908,10 +908,10 @@
       "integrity": "sha1-9G8MdbeEH40gCzNIzU1pHVoJnRU=",
       "dev": true,
       "requires": {
-        "jsonfile": "1.0.1",
-        "mkdirp": "0.3.5",
-        "ncp": "0.4.2",
-        "rimraf": "2.2.8"
+        "jsonfile": "~1.0.1",
+        "mkdirp": "0.3.x",
+        "ncp": "~0.4.2",
+        "rimraf": "~2.2.0"
       },
       "dependencies": {
         "mkdirp": {
@@ -928,9 +928,9 @@
       "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "path-is-inside": "1.0.2",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "path-is-inside": "^1.0.1",
+        "rimraf": "^2.5.2"
       },
       "dependencies": {
         "glob": {
@@ -939,12 +939,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "rimraf": {
@@ -953,7 +953,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -964,10 +964,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "1.1.14"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -982,10 +982,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "fstream-ignore": {
@@ -994,9 +994,9 @@
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
       }
     },
     "fstream-npm": {
@@ -1005,8 +1005,8 @@
       "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
       "dev": true,
       "requires": {
-        "fstream-ignore": "1.0.5",
-        "inherits": "2.0.3"
+        "fstream-ignore": "^1.0.0",
+        "inherits": "2"
       }
     },
     "gauge": {
@@ -1015,14 +1015,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "get-amd-module-type": {
@@ -1031,8 +1031,8 @@
       "integrity": "sha1-5nHsWpatX79To6IqKJ6SOMdy3bA=",
       "dev": true,
       "requires": {
-        "ast-module-types": "2.3.2",
-        "node-source-walk": "3.3.0"
+        "ast-module-types": "^2.3.2",
+        "node-source-walk": "^3.2.0"
       }
     },
     "getpass": {
@@ -1041,7 +1041,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "github-url-from-git": {
@@ -1062,11 +1062,11 @@
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "gonzales-pe": {
@@ -1075,7 +1075,7 @@
       "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
       "dev": true,
       "requires": {
-        "minimist": "1.1.3"
+        "minimist": "1.1.x"
       },
       "dependencies": {
         "minimist": {
@@ -1104,7 +1104,7 @@
       "integrity": "sha1-5ZnkBzPvgOFlO/6JpfAx7PKqSqo=",
       "dev": true,
       "requires": {
-        "temp": "0.4.0"
+        "temp": "~0.4.0"
       }
     },
     "growl": {
@@ -1119,10 +1119,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -1131,7 +1131,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1148,8 +1148,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -1158,7 +1158,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -1179,10 +1179,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -1203,11 +1203,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       }
     },
     "http-signature": {
@@ -1216,9 +1216,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iferr": {
@@ -1239,8 +1239,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1261,11 +1261,11 @@
       "integrity": "sha1-HWM8FRpJCYka/I7hPKzoszbAycI=",
       "dev": true,
       "requires": {
-        "glob": "4.5.3",
-        "promzard": "0.2.2",
-        "read": "1.0.7",
-        "read-package-json": "1.3.3",
-        "semver": "3.0.1"
+        "glob": "^4.0.2",
+        "promzard": "~0.2.0",
+        "read": "~1.0.1",
+        "read-package-json": "1",
+        "semver": "2.x || 3.x || 4"
       },
       "dependencies": {
         "glob": {
@@ -1274,10 +1274,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "minimatch": {
@@ -1286,7 +1286,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
@@ -1303,7 +1303,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -1312,7 +1312,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-relative-path": {
@@ -1351,20 +1351,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       }
     },
     "jju": {
@@ -1379,8 +1379,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -1404,14 +1404,14 @@
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
       }
     },
     "json-parse-helpfulerror": {
@@ -1420,7 +1420,7 @@
       "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
       "dev": true,
       "requires": {
-        "jju": "1.3.0"
+        "jju": "^1.1.0"
       }
     },
     "json-schema": {
@@ -1465,7 +1465,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1481,8 +1481,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -1503,7 +1503,7 @@
       "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
       "dev": true,
       "requires": {
-        "lodash.tostring": "4.1.4"
+        "lodash.tostring": "^4.0.0"
       }
     },
     "log-symbols": {
@@ -1512,7 +1512,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "longest": {
@@ -1553,8 +1553,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -1569,13 +1569,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1584,7 +1584,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1601,7 +1601,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -1616,7 +1616,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1681,12 +1681,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -1707,7 +1707,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -1718,8 +1718,8 @@
       "integrity": "sha1-wKN3HeWM9rzxKu0kdnBsWWrUsss=",
       "dev": true,
       "requires": {
-        "ast-module-types": "2.3.2",
-        "node-source-walk": "3.3.0"
+        "ast-module-types": "^2.3.2",
+        "node-source-walk": "^3.0.0"
       }
     },
     "module-lookup-amd": {
@@ -1728,12 +1728,12 @@
       "integrity": "sha1-WONT+dwB7OwFexzN0A7QWUhKzKU=",
       "dev": true,
       "requires": {
-        "commander": "2.9.0",
-        "debug": "3.1.0",
-        "file-exists": "1.0.0",
+        "commander": "^2.8.1",
+        "debug": "^3.1.0",
+        "file-exists": "~1.0.0",
         "find": "0.2.6",
-        "requirejs": "2.2.0",
-        "requirejs-config-file": "2.0.1"
+        "requirejs": "~2.2.0",
+        "requirejs-config-file": "~2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1771,9 +1771,9 @@
       "integrity": "sha1-mHupYk2JOVOIw3y0dB4sr03ROxo=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "natives": {
@@ -1794,7 +1794,7 @@
       "integrity": "sha1-rRjjW/2z0Lb34OSv8eePhGo7iHM=",
       "dev": true,
       "requires": {
-        "babylon": "6.18.0"
+        "babylon": "^6.17.0"
       }
     },
     "nopt": {
@@ -1803,7 +1803,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -1812,9 +1812,9 @@
       "integrity": "sha1-i+lVuJB6+XXxpFhOqLubQUkjEvU=",
       "dev": true,
       "requires": {
-        "github-url-from-git": "1.5.0",
-        "github-url-from-username-repo": "1.0.2",
-        "semver": "3.0.1"
+        "github-url-from-git": "^1.3.0",
+        "github-url-from-username-repo": "^1.0.0",
+        "semver": "2 || 3 || 4"
       }
     },
     "npm": {
@@ -1823,66 +1823,66 @@
       "integrity": "sha1-wbyFDEsEbUFgztEkH7zC6ZMVnos=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.5",
-        "ansi": "0.3.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "archy": "0.0.2",
-        "async-some": "1.0.1",
+        "abbrev": "~1.0.5",
+        "ansi": "~0.3.0",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "archy": "0",
+        "async-some": "~1.0.1",
         "block-stream": "0.0.7",
-        "char-spinner": "1.0.1",
-        "child-process-close": "0.1.1",
-        "chmodr": "0.1.2",
-        "chownr": "0.0.2",
-        "cmd-shim": "2.0.1",
-        "columnify": "1.2.1",
-        "dezalgo": "1.0.0",
-        "editor": "0.1.0",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "fstream": "1.0.2",
-        "fstream-npm": "1.0.7",
-        "github-url-from-git": "1.4.0",
-        "github-url-from-username-repo": "1.0.2",
-        "glob": "4.0.5",
-        "graceful-fs": "3.0.2",
-        "inflight": "1.0.1",
-        "inherits": "2.0.3",
-        "ini": "1.2.1",
-        "init-package-json": "1.1.3",
-        "lockfile": "1.0.0",
-        "lru-cache": "2.5.2",
-        "minimatch": "1.0.0",
-        "mkdirp": "0.5.0",
-        "node-gyp": "1.0.2",
-        "nopt": "3.0.6",
-        "normalize-package-data": "1.0.2",
-        "npm-cache-filename": "1.0.1",
-        "npm-install-checks": "1.0.4",
-        "npm-package-arg": "2.1.3",
-        "npm-registry-client": "3.2.4",
-        "npm-user-validate": "0.1.5",
-        "npmconf": "2.1.3",
-        "npmlog": "0.1.1",
-        "once": "1.3.3",
-        "opener": "1.3.0",
-        "osenv": "0.1.5",
-        "path-is-inside": "1.0.2",
-        "read": "1.0.7",
-        "read-installed": "3.1.3",
-        "read-package-json": "1.2.7",
-        "request": "2.44.0",
-        "retry": "0.6.1",
-        "rimraf": "2.2.8",
-        "semver": "4.0.0",
-        "sha": "1.2.4",
-        "slide": "1.1.6",
-        "sorted-object": "1.0.0",
-        "tar": "1.0.1",
-        "text-table": "0.2.0",
+        "char-spinner": "~1.0.1",
+        "child-process-close": "~0.1.1",
+        "chmodr": "~0.1.0",
+        "chownr": "0",
+        "cmd-shim": "~2.0.1",
+        "columnify": "~1.2.1",
+        "dezalgo": "*",
+        "editor": "~0.1.0",
+        "fs-vacuum": "~1.2.1",
+        "fs-write-stream-atomic": "~1.0.0",
+        "fstream": "~1.0.2",
+        "fstream-npm": "~1.0.0",
+        "github-url-from-git": "~1.4.0",
+        "github-url-from-username-repo": "~1.0.2",
+        "glob": "~4.0.5",
+        "graceful-fs": "~3.0.0",
+        "inflight": "~1.0.1",
+        "inherits": "*",
+        "ini": "~1.2.0",
+        "init-package-json": "~1.1.0",
+        "lockfile": "~1.0.0",
+        "lru-cache": "~2.5.0",
+        "minimatch": "~1.0.0",
+        "mkdirp": "~0.5.0",
+        "node-gyp": "~1.0.1",
+        "nopt": "~3.0.1",
+        "normalize-package-data": "~1.0.1",
+        "npm-cache-filename": "~1.0.1",
+        "npm-install-checks": "~1.0.2",
+        "npm-package-arg": "~2.1.2",
+        "npm-registry-client": "~3.2.2",
+        "npm-user-validate": "~0.1.0",
+        "npmconf": "~2.1.0",
+        "npmlog": "~0.1.1",
+        "once": "~1.3.0",
+        "opener": "~1.3.0",
+        "osenv": "~0.1.0",
+        "path-is-inside": "~1.0.0",
+        "read": "~1.0.4",
+        "read-installed": "~3.1.2",
+        "read-package-json": "~1.2.7",
+        "request": "~2.44.0",
+        "retry": "~0.6.0",
+        "rimraf": "~2.2.8",
+        "semver": "~4.0.0",
+        "sha": "~1.2.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~1.0.0",
+        "tar": "~1.0.1",
+        "text-table": "~0.2.0",
         "uid-number": "0.0.5",
-        "which": "1.3.0",
-        "write-file-atomic": "1.1.0"
+        "which": "1",
+        "write-file-atomic": "~1.1.0"
       },
       "dependencies": {
         "abbrev": {
@@ -1903,7 +1903,7 @@
           "integrity": "sha1-i1TwjUbw+bq8cuqdZGwkXSOk2eU=",
           "dev": true,
           "requires": {
-            "dezalgo": "1.0.0"
+            "dezalgo": "^1.0.0"
           }
         },
         "char-spinner": {
@@ -1918,8 +1918,8 @@
           "integrity": "sha1-RRKjc9I5FnmuxRrR1HM1Wem4XUo=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.2",
-            "mkdirp": "0.5.0"
+            "graceful-fs": ">3.0.1 <4.0.0-0",
+            "mkdirp": "~0.5.0"
           }
         },
         "columnify": {
@@ -1928,8 +1928,8 @@
           "integrity": "sha1-kh7FHBePQSbTwH6azs1npVx5U+Q=",
           "dev": true,
           "requires": {
-            "strip-ansi": "1.0.0",
-            "wcwidth": "1.0.0"
+            "strip-ansi": "^1.0.0",
+            "wcwidth": "^1.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -1938,7 +1938,7 @@
               "integrity": "sha1-bAITIdbs4WGjxgj7qyaMcyiQHHM=",
               "dev": true,
               "requires": {
-                "ansi-regex": "0.2.1"
+                "ansi-regex": "^0.2.1"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -1955,7 +1955,7 @@
               "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
               "dev": true,
               "requires": {
-                "defaults": "1.0.0"
+                "defaults": "^1.0.0"
               },
               "dependencies": {
                 "defaults": {
@@ -1964,7 +1964,7 @@
                   "integrity": "sha1-OuJfREFsbAH5gJol/N0oWRLSprE=",
                   "dev": true,
                   "requires": {
-                    "clone": "0.1.18"
+                    "clone": "~0.1.5"
                   },
                   "dependencies": {
                     "clone": {
@@ -1985,7 +1985,7 @@
           "integrity": "sha1-BQu3I/GLVhezCfJsLcj+byVztvw=",
           "dev": true,
           "requires": {
-            "asap": "1.0.0"
+            "asap": "^1.0.0"
           },
           "dependencies": {
             "asap": {
@@ -2008,10 +2008,10 @@
           "integrity": "sha1-VpMP8bTU17GmichlazoR50SrksY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.2",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.0",
-            "rimraf": "2.2.8"
+            "graceful-fs": "3",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "github-url-from-git": {
@@ -2026,10 +2026,10 @@
           "integrity": "sha1-leQsnv2zqx9HiP13k9/e1KM3gGM=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.2",
-            "inherits": "2.0.3",
-            "minimatch": "1.0.0",
-            "once": "1.3.3"
+            "graceful-fs": "^3.0.2",
+            "inherits": "2",
+            "minimatch": "^1.0.0",
+            "once": "^1.3.0"
           }
         },
         "graceful-fs": {
@@ -2044,7 +2044,7 @@
           "integrity": "sha1-AfaRGCFTUkPHkKwPmY9U6QI/+28=",
           "dev": true,
           "requires": {
-            "once": "1.3.3"
+            "once": "^1.3.0"
           }
         },
         "ini": {
@@ -2065,8 +2065,8 @@
           "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.5.2",
-            "sigmund": "1.0.0"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           },
           "dependencies": {
             "sigmund": {
@@ -2100,19 +2100,19 @@
           "integrity": "sha1-sLttLXYicUCN2QSFPnqjAA7S61c=",
           "dev": true,
           "requires": {
-            "fstream": "1.0.2",
-            "glob": "4.0.5",
-            "graceful-fs": "3.0.2",
-            "minimatch": "1.0.0",
-            "mkdirp": "0.5.0",
-            "nopt": "3.0.6",
-            "npmlog": "0.1.1",
-            "osenv": "0.1.5",
-            "request": "2.44.0",
-            "rimraf": "2.2.8",
-            "semver": "4.0.0",
-            "tar": "1.0.1",
-            "which": "1.3.0"
+            "fstream": "^1.0.0",
+            "glob": "3 || 4",
+            "graceful-fs": "3",
+            "minimatch": "1",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0",
+            "osenv": "0",
+            "request": "2",
+            "rimraf": "2",
+            "semver": "2.x || 3.x || 4",
+            "tar": "^1.0.0",
+            "which": "1"
           }
         },
         "normalize-package-data": {
@@ -2121,9 +2121,9 @@
           "integrity": "sha1-MqkCrTytMobxEGublVAGL0TuIRg=",
           "dev": true,
           "requires": {
-            "github-url-from-git": "1.4.0",
-            "github-url-from-username-repo": "1.0.2",
-            "semver": "4.0.0"
+            "github-url-from-git": "^1.3.0",
+            "github-url-from-username-repo": "^1.0.0",
+            "semver": "2 || 3 || 4"
           }
         },
         "npm-cache-filename": {
@@ -2138,8 +2138,8 @@
           "integrity": "sha1-l1fG+dTUk8JIlGXabQeo7UFtRMg=",
           "dev": true,
           "requires": {
-            "npmlog": "0.1.1",
-            "semver": "4.0.0"
+            "npmlog": "0.1",
+            "semver": "^2.3.0 || 3.x || 4"
           }
         },
         "once": {
@@ -2148,7 +2148,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "read-installed": {
@@ -2157,13 +2157,13 @@
           "integrity": "sha1-wJCSoTwhF/IoQsrRaATzsFkSnRE=",
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "3.0.2",
-            "read-package-json": "1.2.7",
-            "readdir-scoped-modules": "1.0.0",
-            "semver": "4.0.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.1"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "2 || 3",
+            "read-package-json": "1",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           },
           "dependencies": {
             "debuglog": {
@@ -2178,9 +2178,9 @@
               "integrity": "sha1-6Tnelps4s+ffqhT7z+ei/RWk6jc=",
               "dev": true,
               "requires": {
-                "debuglog": "1.0.1",
-                "dezalgo": "1.0.0",
-                "once": "1.3.3"
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "once": "^1.3.0"
               }
             },
             "util-extend": {
@@ -2197,12 +2197,12 @@
           "integrity": "sha1-8LRAxGGiGPTb9IsJToD8ZcUkhQI=",
           "dev": true,
           "requires": {
-            "github-url-from-git": "1.4.0",
-            "github-url-from-username-repo": "1.0.2",
-            "glob": "4.0.5",
-            "graceful-fs": "3.0.2",
-            "lru-cache": "2.5.2",
-            "normalize-package-data": "1.0.2"
+            "github-url-from-git": "^1.3.0",
+            "github-url-from-username-repo": "~1.0.0",
+            "glob": "^4.0.2",
+            "graceful-fs": "2 || 3",
+            "lru-cache": "2",
+            "normalize-package-data": "^1.0.0"
           }
         },
         "request": {
@@ -2211,21 +2211,21 @@
           "integrity": "sha1-eNYkVNaIU8rfsHrTH1i57JgHLqg=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.5.0",
-            "bl": "0.9.3",
-            "caseless": "0.6.0",
-            "forever-agent": "0.5.2",
-            "form-data": "0.1.4",
+            "aws-sign2": "~0.5.0",
+            "bl": "~0.9.0",
+            "caseless": "~0.6.0",
+            "forever-agent": "~0.5.0",
+            "form-data": "~0.1.0",
             "hawk": "1.1.1",
-            "http-signature": "0.10.0",
-            "json-stringify-safe": "5.0.0",
-            "mime-types": "1.0.2",
-            "node-uuid": "1.4.1",
-            "oauth-sign": "0.4.0",
-            "qs": "1.2.2",
-            "stringstream": "0.0.4",
-            "tough-cookie": "0.12.1",
-            "tunnel-agent": "0.4.0"
+            "http-signature": "~0.10.0",
+            "json-stringify-safe": "~5.0.0",
+            "mime-types": "~1.0.1",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.4.0",
+            "qs": "~1.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": ">=0.12.0",
+            "tunnel-agent": "~0.4.0"
           },
           "dependencies": {
             "aws-sign2": {
@@ -2241,7 +2241,7 @@
               "integrity": "sha1-xB7/PnyzG94QfI8QB20nTv9/fUQ=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.31"
+                "readable-stream": "~1.0.26"
               },
               "dependencies": {
                 "readable-stream": {
@@ -2250,10 +2250,10 @@
                   "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.1",
-                    "inherits": "2.0.3",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -2297,9 +2297,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "async": "0.9.0",
-                "combined-stream": "0.0.5",
-                "mime": "1.2.11"
+                "async": "~0.9.0",
+                "combined-stream": "~0.0.4",
+                "mime": "~1.2.11"
               },
               "dependencies": {
                 "async": {
@@ -2344,10 +2344,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "boom": "0.4.2",
-                "cryptiles": "0.2.2",
-                "hoek": "0.9.1",
-                "sntp": "0.2.4"
+                "boom": "0.4.x",
+                "cryptiles": "0.2.x",
+                "hoek": "0.9.x",
+                "sntp": "0.2.x"
               },
               "dependencies": {
                 "boom": {
@@ -2356,7 +2356,7 @@
                   "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
                   "dev": true,
                   "requires": {
-                    "hoek": "0.9.1"
+                    "hoek": "0.9.x"
                   }
                 },
                 "cryptiles": {
@@ -2366,7 +2366,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "boom": "0.4.2"
+                    "boom": "0.4.x"
                   }
                 },
                 "hoek": {
@@ -2382,7 +2382,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "hoek": "0.9.1"
+                    "hoek": "0.9.x"
                   }
                 }
               }
@@ -2467,7 +2467,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "punycode": "1.3.1"
+                "punycode": ">=0.2.0"
               },
               "dependencies": {
                 "punycode": {
@@ -2505,8 +2505,8 @@
           "integrity": "sha1-H5o3fye2/e5Am5uFjkPacCvkik0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.2",
-            "readable-stream": "1.0.31"
+            "graceful-fs": "2 || 3",
+            "readable-stream": "1.0"
           },
           "dependencies": {
             "readable-stream": {
@@ -2516,10 +2516,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "core-util-is": "1.0.1",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               },
               "dependencies": {
                 "core-util-is": {
@@ -2559,9 +2559,9 @@
           "integrity": "sha1-YHW1ofI23v4MfjdW09mz69rQ8Zo=",
           "dev": true,
           "requires": {
-            "block-stream": "0.0.7",
-            "fstream": "1.0.2",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "uid-number": {
@@ -2576,8 +2576,8 @@
           "integrity": "sha1-4RTPuPghiDU/mCF8WUVFHJtNwGA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.2",
-            "slide": "1.1.6"
+            "graceful-fs": "^3.0.2",
+            "slide": "^1.1.5"
           }
         }
       }
@@ -2594,7 +2594,7 @@
       "integrity": "sha1-37o0vYLdMnwQy0OmXI227wuBK/c=",
       "dev": true,
       "requires": {
-        "semver": "4.3.6"
+        "semver": "4"
       },
       "dependencies": {
         "semver": {
@@ -2611,18 +2611,18 @@
       "integrity": "sha1-hlmzRJ4cmp+BgdrRQsrbBIv+Uh8=",
       "dev": true,
       "requires": {
-        "chownr": "0.0.2",
-        "graceful-fs": "3.0.11",
-        "mkdirp": "0.5.1",
-        "normalize-package-data": "1.0.3",
-        "npm-cache-filename": "1.0.2",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "request": "2.86.0",
-        "retry": "0.6.1",
-        "rimraf": "2.2.8",
-        "semver": "3.0.1",
-        "slide": "1.1.6"
+        "chownr": "0",
+        "graceful-fs": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "normalize-package-data": "~1.0.1",
+        "npm-cache-filename": "^1.0.0",
+        "npmlog": "^4.1.2",
+        "once": "^1.3.0",
+        "request": "2 >=2.25.0",
+        "retry": "^0.6.1",
+        "rimraf": "2",
+        "semver": "2 >=2.2.1 || 3.x || 4",
+        "slide": "^1.1.3"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2631,7 +2631,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.3"
+            "natives": "^1.1.0"
           }
         },
         "npmlog": {
@@ -2640,10 +2640,10 @@
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         }
       }
@@ -2660,15 +2660,15 @@
       "integrity": "sha512-iTK+HI68GceCoGOHAQiJ/ik1iDfI7S+cgyG8A+PP18IU3X83kRhQIRhAUNj4Bp2JMx6Zrt5kCiozYa9uGWTjhA==",
       "dev": true,
       "requires": {
-        "config-chain": "1.1.11",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.3.3",
-        "osenv": "0.1.5",
-        "safe-buffer": "5.1.1",
-        "semver": "3.0.1",
+        "config-chain": "~1.1.8",
+        "inherits": "~2.0.0",
+        "ini": "^1.2.0",
+        "mkdirp": "^0.5.0",
+        "nopt": "~3.0.1",
+        "once": "~1.3.0",
+        "osenv": "^0.1.0",
+        "safe-buffer": "^5.1.1",
+        "semver": "2 || 3 || 4",
         "uid-number": "0.0.5"
       },
       "dependencies": {
@@ -2678,7 +2678,7 @@
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -2689,11 +2689,11 @@
       "integrity": "sha1-0iiZOdzpqdqZLj0sTWYsb4EKsk4=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "npm": "2.0.2",
-        "optimist": "0.6.1",
-        "semver": "3.0.1",
-        "valentine": "2.1.4"
+        "async": "0.9.x",
+        "npm": "2.0.x",
+        "optimist": "0.6.x",
+        "semver": "3.0.x",
+        "valentine": "2.1.x"
       },
       "dependencies": {
         "async": {
@@ -2710,7 +2710,7 @@
       "integrity": "sha1-i5ueRAXX7EjDHCNGllqtx6uuyqU=",
       "dev": true,
       "requires": {
-        "ansi": "0.3.1"
+        "ansi": "~0.3.0"
       }
     },
     "number-is-nan": {
@@ -2737,7 +2737,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -2746,7 +2746,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opener": {
@@ -2761,8 +2761,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -2779,12 +2779,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "ora": {
@@ -2793,10 +2793,10 @@
       "integrity": "sha1-Mvsxg1AO/oP16okQF4Xw7mBg/sk=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
-        "log-symbols": "1.0.2"
+        "chalk": "^1.1.1",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^1.0.0",
+        "log-symbols": "^1.0.2"
       }
     },
     "os-homedir": {
@@ -2817,8 +2817,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "parse-ms": {
@@ -2863,18 +2863,18 @@
       "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
-        "debug": "3.1.0",
-        "detective-amd": "2.4.0",
-        "detective-cjs": "2.0.0",
-        "detective-es6": "1.2.0",
+        "commander": "^2.11.0",
+        "debug": "^3.0.1",
+        "detective-amd": "^2.4.0",
+        "detective-cjs": "^2.0.0",
+        "detective-es6": "^1.2.0",
         "detective-less": "1.0.0",
-        "detective-sass": "2.0.1",
-        "detective-scss": "1.0.1",
-        "detective-stylus": "1.0.0",
-        "detective-typescript": "1.0.1",
-        "module-definition": "2.2.4",
-        "node-source-walk": "3.3.0"
+        "detective-sass": "^2.0.0",
+        "detective-scss": "^1.0.0",
+        "detective-stylus": "^1.0.0",
+        "detective-typescript": "^1.0.0",
+        "module-definition": "^2.2.4",
+        "node-source-walk": "^3.3.0"
       },
       "dependencies": {
         "commander": {
@@ -2912,9 +2912,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2",
-        "parse-ms": "1.0.1",
-        "plur": "1.0.0"
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
       }
     },
     "process-nextick-args": {
@@ -2929,7 +2929,7 @@
       "integrity": "sha1-kYufKylFjLABeBqIVlAuSnmwFuA=",
       "dev": true,
       "requires": {
-        "read": "1.0.7"
+        "read": "1"
       }
     },
     "proto-list": {
@@ -2962,10 +2962,10 @@
       "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "1.0.4"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~1.0.4"
       },
       "dependencies": {
         "minimist": {
@@ -2982,7 +2982,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "0.0.7"
+        "mute-stream": "~0.0.4"
       }
     },
     "read-package-json": {
@@ -2991,10 +2991,10 @@
       "integrity": "sha1-73nf2kbhZTdu6KV++/7dTRsCm6Q=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15",
-        "graceful-fs": "3.0.11",
-        "json-parse-helpfulerror": "1.0.3",
-        "normalize-package-data": "1.0.3"
+        "glob": "^5.0.3",
+        "graceful-fs": "2 || 3",
+        "json-parse-helpfulerror": "^1.0.2",
+        "normalize-package-data": "^1.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -3004,7 +3004,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "natives": "1.1.3"
+            "natives": "^1.1.0"
           }
         }
       }
@@ -3015,10 +3015,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "regenerator-runtime": {
@@ -3039,27 +3039,27 @@
       "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "requirejs": {
@@ -3074,9 +3074,9 @@
       "integrity": "sha1-HykScD48TfiYKyx73deipk/Rb7k=",
       "dev": true,
       "requires": {
-        "esprima": "1.0.4",
-        "fs-extra": "0.6.4",
-        "stringify-object": "0.1.8"
+        "esprima": "~1.0.4",
+        "fs-extra": "~0.6.4",
+        "stringify-object": "~0.1.7"
       },
       "dependencies": {
         "esprima": {
@@ -3105,8 +3105,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "retry": {
@@ -3122,7 +3122,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -3143,8 +3143,8 @@
       "integrity": "sha1-2kSiG+6llV8U7/24G97idRttFeI=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1",
-        "is-relative-path": "1.0.2"
+        "commander": "~2.8.1",
+        "is-relative-path": "~1.0.0"
       },
       "dependencies": {
         "commander": {
@@ -3153,7 +3153,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         }
       }
@@ -3194,7 +3194,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "sorted-object": {
@@ -3210,7 +3210,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
@@ -3225,14 +3225,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "string-width": {
@@ -3241,9 +3241,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -3264,7 +3264,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-json-comments": {
@@ -3279,9 +3279,9 @@
       "integrity": "sha1-eVm+rAu1V+vROvO8Osvu/7J2YNQ=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1",
-        "debug": "3.1.0",
-        "is-relative-path": "1.0.2"
+        "commander": "~2.8.1",
+        "debug": "^3.1.0",
+        "is-relative-path": "~1.0.0"
       },
       "dependencies": {
         "commander": {
@@ -3290,7 +3290,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "debug": {
@@ -3316,7 +3316,7 @@
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "tapable": {
@@ -3343,7 +3343,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -3352,7 +3352,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "tough-cookie": {
@@ -3361,7 +3361,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse-chain": {
@@ -3376,7 +3376,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -3392,7 +3392,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typescript": {
@@ -3408,7 +3408,7 @@
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.0",
-        "object-assign": "4.1.1"
+        "object-assign": "^4.0.1"
       }
     },
     "uglify-js": {
@@ -3418,9 +3418,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -3469,9 +3469,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "walkdir": {
@@ -3486,7 +3486,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wide-align": {
@@ -3495,7 +3495,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "window-size": {
@@ -3524,9 +3524,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -162,6 +162,14 @@ describe("i18n for iso 3166-1", function () {
     it("isValid ... => false", function() {
       assert.equal(i18niso.isValid('...'), false);
     });
+    it("isValid is case insensitive", function() {
+      assert.equal(i18niso.isValid('fra'), true);
+      assert.equal(i18niso.isValid('fr'), true);
+    });
+    it("isValid works with undefined or null", function() {
+      assert.equal(i18niso.isValid(undefined), false);
+      assert.equal(i18niso.isValid(null), false);
+    });
   });
   describe("completeness", function () {
     i18niso.langs().forEach(function(lang) {


### PR DESCRIPTION
Previously, the isValid function was ok with valid lowercase iso codes. A change at 3.6.2 made this behaviour change, causing a breaking change in a minor version change.
I guess that it has been inserted by mistake, so i have taken the liberty of changing that in this PR.