### PR TITLE
Fix "typings" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "i18n-iso-countries",
   "version": "3.7.6",
   "description": "i18n for ISO 3166-1 country codes",
-  "typings": "index.d.js",
+  "typings": "index.d.ts",
   "keywords": [
     "i18n",
     "iso",


### PR DESCRIPTION
Before, this was pointing to the nonexistent `index.d.js` rather than the actually-existing `index.d.ts`.