### PR TITLE
Fixed New Zealand translation

### DIFF
--- a/langs/es.json
+++ b/langs/es.json
@@ -152,7 +152,7 @@
     "NP": "Nepal",
     "NL": "Países Bajos",
     "NC": "Nueva Caledonia",
-    "NZ": "Nueva Zelandia",
+    "NZ": "Nueva Zelanda",
     "NI": "Nicaragua",
     "NE": "Níger",
     "NG": "Nigeria",


### PR DESCRIPTION
It's Nueva Zelanda, not Nueva Zelandia