### PR TITLE
Update english name for Libya

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -121,7 +121,7 @@
     "LB": "Lebanon",
     "LS": "Lesotho",
     "LR": "Liberia",
-    "LY": "Libyan Arab Jamahiriya",
+    "LY": "Libya",
     "LI": "Liechtenstein",
     "LT": "Lithuania",
     "LU": "Luxembourg",


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Libya

https://www.iso.org/files/live/sites/isoorg/files/archive/pdf/en/nl_vi-11_name_change_for_libya.pdf