### PR TITLE
Retrieve alpha 2 and 3 codes ignoring diacritics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-export type LocalizedCountryNames = { 
-  [alpha2Key: string]: string 
+export type LocalizedCountryNames = {
+  [alpha2Key: string]: string
 };
 
 export type LocaleData = {
@@ -31,6 +31,8 @@ export function getNames(lang: string): LocalizedCountryNames;
 export function toAlpha3(alpha2orNumeric: number | string): string;
 export function toAlpha2(alpha3orNumeric: number | string): string;
 export function getAlpha2Code(name: string, lang: string): string;
+export function getSimpleAlpha2Code(name: string, lang: string): string;
 export function getAlpha3Code(name: string, lang: string): string;
+export function getSimpleAlpha3Code(name: string, lang: string): string;
 export function langs(): string[];
 export function isValid(alpha2orAlpha3orNumeric: string | number): boolean;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var codes = require("./codes.json");
+var removeDiacritics = require('diacritics').remove;
 var registeredLocales = {};
 
 /*
@@ -187,6 +188,27 @@ exports.getAlpha2Code = function(name, lang) {
 };
 
 /*
+ * @param name name
+ * @param lang language for country name
+ * @return ISO 3166-1 alpha-2 or undefined
+ */
+exports.getSimpleAlpha2Code = function(name, lang) {
+  try {
+    var p, codenames = registeredLocales[lang.toLowerCase()];
+    for (p in codenames) {
+      if (codenames.hasOwnProperty(p)) {
+        if (removeDiacritics(codenames[p].toLowerCase()) === removeDiacritics(name.toLowerCase())) {
+          return p;
+        }
+      }
+    }
+    return undefined;
+  } catch (err) {
+    return undefined;
+  }
+};
+
+/*
  * @return Object of alpha-2 codes mapped to alpha-3 codes
  */
 exports.getAlpha2Codes = function() {
@@ -200,6 +222,20 @@ exports.getAlpha2Codes = function() {
  */
 exports.getAlpha3Code = function(name, lang) {
   var alpha2 = this.getAlpha2Code(name, lang);
+  if (alpha2) {
+    return this.toAlpha3(alpha2);
+  } else {
+    return undefined;
+  }
+};
+
+/*
+ * @param name name
+ * @param lang language for country name
+ * @return ISO 3166-1 alpha-3 or undefined
+ */
+exports.getSimpleAlpha3Code = function(name, lang) {
+  var alpha2 = this.getSimpleAlpha2Code(name, lang);
   if (alpha2) {
     return this.toAlpha3(alpha2);
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -457,6 +457,11 @@
         }
       }
     },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "type": "git",
     "url": "https://github.com/michaelwittig/node-i18n-iso-countries.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "diacritics": "^1.3.0"
+  },
   "devDependencies": {
     "assert-plus": "1.0.0",
     "mocha": "6.1.4",

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -132,12 +132,36 @@ describe("i18n for iso 3166-1", function () {
       assert.equal(i18niso.getAlpha2Code("Deutschland", "xx"), undefined);
     });
   });
+  describe("getSimpleAlpha2Code", function() {
+    it("works", function() {
+      assert.equal(i18niso.getSimpleAlpha2Code("belgie", "nl"), 'BE');
+      assert.equal(i18niso.getSimpleAlpha2Code("België", "nl"), 'BE');
+    });
+    it("missing name", function() {
+      assert.equal(i18niso.getSimpleAlpha2Code("XXX", "de"), undefined);
+    });
+    it("missing land", function() {
+      assert.equal(i18niso.getSimpleAlpha2Code("Deutschland", "xx"), undefined);
+    });
+  });
   describe("getAlpha3Code", function() {
     it("missing name", function() {
       assert.equal(i18niso.getAlpha3Code("XXX", "de"), undefined);
     });
     it("missing land", function() {
       assert.equal(i18niso.getAlpha3Code("Deutschland", "xx"), undefined);
+    });
+  });
+  describe("getSimpleAlpha3Code", function() {
+    it("works", function() {
+      assert.equal(i18niso.getSimpleAlpha3Code("belgie", "nl"), 'BEL');
+      assert.equal(i18niso.getSimpleAlpha3Code("België", "nl"), 'BEL');
+    });
+    it("missing name", function() {
+      assert.equal(i18niso.getSimpleAlpha3Code("XXX", "de"), undefined);
+    });
+    it("missing land", function() {
+      assert.equal(i18niso.getSimpleAlpha3Code("Deutschland", "xx"), undefined);
     });
   });
   describe("isValid", function() {


### PR DESCRIPTION
`getSimpleAlpha2Code()` and `getSimpleAlpha3Code()` allow you to get country codes with less precise user input by ignoring diacritics (in addition to capitals).

For example, `getAlpha2Code('Belgie', 'nl')` currently returns `undefined` because the correct spelling is "België". The functions I added use [diacritic](https://www.npmjs.com/package/diacritics) to remove diacritics/accents while comparing values so they return the correct country code regardless. So now `getSimpleAlpha2Code('Belgie', 'nl')` will return `BE`.