### PR TITLE
add "undefined" return type to typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,13 +26,72 @@ export function getAlpha3Codes(): { [alpha3Key: string]: string };
  * Returns object map where key is numeric code and value is alpha 2 code
  */
 export function getNumericCodes(): { [numericKey: string]: string };
-export function getName(alpha2orAlpha3orNumeric: string | number, lang: string): string;
-export function getNames(lang: string): LocalizedCountryNames;
+
+export type LanguageCode =
+  | 'ar' // Arabic
+  | 'az' // Azerbaijani
+  | 'be' // Belorussian
+  | 'bg' // Bulgarian
+  | 'bs' // Bosnian
+  | 'ca' // Catalan
+  | 'cs' // Czech
+  | 'da' // Danish
+  | 'de' // German
+  | 'en' // English
+  | 'es' // Spanish
+  | 'et' // Estonian
+  | 'fa' // Persian
+  | 'fi' // Finnish
+  | 'fr' // French
+  | 'el' // Greek
+  | 'he' // Hebrew
+  | 'hr' // Croatian
+  | 'hu' // Hungarian
+  | 'hy' // Armenian
+  | 'it' // Italian
+  | 'id' // Indonesian
+  | 'ja' // Japanese
+  | 'ka' // Georgian
+  | 'kk' // Kazakh
+  | 'ko' // Korean
+  | 'ky' // Kyrgyz
+  | 'lt' // Lithuanian
+  | 'lv' // Latvian
+  | 'mk' // Macedonian
+  | 'mn' // Mongolian
+  | 'ms' // Malay
+  | 'nb' // Norwegian Bokmål
+  | 'nl' // Dutch
+  | 'nn' // Norwegian Nynorsk
+  | 'pl' // Polish
+  | 'pt' // Portuguese
+  | 'ro' // Romanian
+  | 'ru' // Russian
+  | 'sk' // Slovak
+  | 'sl' // Slovene
+  | 'sr' // Serbian
+  | 'sv' // Swedish
+  | 'th' // Thai
+  | 'tr' // Turkish
+  | 'uk' // Ukrainian
+  | 'ur' // Urdu
+  | 'uz' // Uzbek
+  | 'zh' // Chinese
+  | 'vi' // Vietnamese
+
+export function getName(alpha2orAlpha3orNumeric: string | number, lang: LanguageCode): string;
+export function getName(alpha2orAlpha3orNumeric: string | number, lang: string): string | undefined;
+export function getNames(lang: LanguageCode): LocalizedCountryNames;
+export function getNames(lang: string): LocalizedCountryNames | {};
 export function toAlpha3(alpha2orNumeric: number | string): string;
 export function toAlpha2(alpha3orNumeric: number | string): string;
-export function getAlpha2Code(name: string, lang: string): string;
-export function getSimpleAlpha2Code(name: string, lang: string): string;
-export function getAlpha3Code(name: string, lang: string): string;
-export function getSimpleAlpha3Code(name: string, lang: string): string;
+export function getAlpha2Code(name: string, lang: LanguageCode): string;
+export function getAlpha2Code(name: string, lang: string): string | undefined;
+export function getSimpleAlpha2Code(name: string, lang: LanguageCode): string;
+export function getSimpleAlpha2Code(name: string, lang: string): string | undefined;
+export function getAlpha3Code(name: string, lang: LanguageCode): string;
+export function getAlpha3Code(name: string, lang: string): string | undefined;
+export function getSimpleAlpha3Code(name: string, lang: LanguageCode): string;
+export function getSimpleAlpha3Code(name: string, lang: string): string | undefined;
 export function langs(): string[];
 export function isValid(alpha2orAlpha3orNumeric: string | number): boolean;


### PR DESCRIPTION
There are translations only for a subset of languages being supported. For non-supported languages, [`undefined` value is returned](https://github.com/michaelwittig/node-i18n-iso-countries/blob/master/index.js#L143-L155). This commit improves autocomplete for the second argument and refines the return type.

May break users' code if the second argument has `string` type. There are two solutions:

```js
// cast the 2nd argument
const lang: string = 'en'
const name: string = getName('RU', lang as LanguageCode)

// cast the return type
const lang: string = 'en'
const name: string = getName('RU', lang) as string
```

If you don't like the changes are breaking, I can replace `string | undefined` with just `string`, so we'll have only an improved autocomplete. But bugs are still possible and that's why we have type systems...