### PR TITLE
Fix name of CG for fr locale

### DIFF
--- a/langs/fr.json
+++ b/langs/fr.json
@@ -49,7 +49,7 @@
     "CC": "Cocos",
     "CO": "Colombie",
     "KM": "Comores",
-    "CG": "Congo, République populaire",
+    "CG": "République du Congo",
     "CD": "Congo, République démocratique",
     "CK": "Îles Cook",
     "CR": "Costa Rica",


### PR DESCRIPTION
Dear maintainers,

I run a [website that tracks Covid-19 around the world](https://covidvision.org/), and one of my reader notified me that the name for Congo (CG) was wrong in the French locale.

I have corrected it, using the data on the Wikipedia [ISO 3166-1](https://fr.wikipedia.org/wiki/ISO_3166-1) page as a source.