### PR TITLE
fix: rename Swaziland to Eswatini

### DIFF
--- a/langs/da.json
+++ b/langs/da.json
@@ -202,7 +202,7 @@
     "SD": "Sudan",
     "SR": "Surinam",
     "SJ": "Norge Svalbard og Jan Mayen",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "SE": "Sverige",
     "CH": "Schweiz",
     "SY": "Syrien",

--- a/langs/en.json
+++ b/langs/en.json
@@ -202,7 +202,7 @@
     "SD": "Sudan",
     "SR": "Suriname",
     "SJ": "Svalbard and Jan Mayen",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "SE": "Sweden",
     "CH": "Switzerland",
     "SY": "Syrian Arab Republic",

--- a/langs/id.json
+++ b/langs/id.json
@@ -202,7 +202,7 @@
     "SD": "Sudan",
     "SR": "Suriname",
     "SJ": "Svalbard dan Jan Mayen",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "SE": "Sweden",
     "CH": "Swiss",
     "SY": "Suriah",

--- a/langs/it.json
+++ b/langs/it.json
@@ -213,7 +213,7 @@
     "SV": "El Salvador",
     "SX": "Sint Maarten",
     "SY": "Siria",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "TC": "Isole Turks e Caicos",
     "TD": "Ciad",
     "TF": "Territori Francesi del Sud",

--- a/langs/ms.json
+++ b/langs/ms.json
@@ -213,7 +213,7 @@
     "SV": "El Salvador",
     "SX": "Sint Maarten",
     "SY": "Syria",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "TC": "Kepulauan Turks dan Caicos",
     "TD": "Chad",
     "TF": "Wilayah Selatan Perancis",
@@ -253,4 +253,3 @@
     "ZW": "Zimbabwe"
   }
 }
-  

--- a/langs/nb.json
+++ b/langs/nb.json
@@ -213,7 +213,7 @@
     "SV": "El Salvador",
     "SX": "Sint Maarten (Nederlandsk del)",
     "SY": "Syria",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "TC": "Turks- og Caicosøyene",
     "TD": "Tsjad",
     "TF": "Søre franske territorier",

--- a/langs/nn.json
+++ b/langs/nn.json
@@ -213,7 +213,7 @@
     "SV": "El Salvador",
     "SX": "Sint Maarten (Nederlandsk del)",
     "SY": "Syria",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "TC": "Turks- og Caicosøyane",
     "TD": "Tsjad",
     "TF": "Søre franske territorier",

--- a/langs/ro.json
+++ b/langs/ro.json
@@ -213,7 +213,7 @@
     "SV": "El Salvador",
     "SX": "Sint-Maarten",
     "SY": "Siria",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "TC": "Insulele Turks și Caicos",
     "TD": "Ciad",
     "TF": "Teritoriile Australe și Antarctice Franceze",

--- a/langs/sv.json
+++ b/langs/sv.json
@@ -213,7 +213,7 @@
     "SV": "El Salvador",
     "SX": "Sint Maarten (nederländska delen)",
     "SY": "Syrien",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "TC": "Turks- och Caicosöarna",
     "TD": "Tchad",
     "TF": "Franska södra territorierna",

--- a/langs/vi.json
+++ b/langs/vi.json
@@ -202,7 +202,7 @@
     "SD": "Sudan",
     "SR": "Suriname",
     "SJ": "Svalbard and Jan Mayen",
-    "SZ": "Swaziland",
+    "SZ": "Eswatini",
     "SE": "Sweden",
     "CH": "Switzerland",
     "SY": "Syrian Arab Republic",


### PR DESCRIPTION
In 2018, "Swaziland" was officially renamed to "Eswatini":

https://en.wikipedia.org/wiki/Eswatini
https://www.bbc.com/news/world-africa-43821512