### PR TITLE
fix: rename Swaziland to Eswatini (FR+NL)

### DIFF
--- a/langs/fr.json
+++ b/langs/fr.json
@@ -202,7 +202,7 @@
     "SD": "Soudan",
     "SR": "Suriname",
     "SJ": "Svalbard et Île Jan Mayen",
-    "SZ": "Ngwane, Royaume du Swaziland",
+    "SZ": "Ngwane, Royaume d'Eswatini",
     "SE": "Suède",
     "CH": "Suisse",
     "SY": "Syrie",

--- a/langs/nl.json
+++ b/langs/nl.json
@@ -202,7 +202,7 @@
     "SD": "Soedan",
     "SR": "Suriname",
     "SJ": "Spitsbergen en Jan Mayen",
-    "SZ": "Ngwane, Koninkrijk Swaziland",
+    "SZ": "Ngwane, Koninkrijk Eswatini",
     "SE": "Zweden",
     "CH": "Zwitserland",
     "SY": "Syrië",


### PR DESCRIPTION
Following this PR :
https://github.com/michaelwittig/node-i18n-iso-countries/pull/170

The changes for 2 languages were missed.
Here is the fixed version for FR and NL.

https://fr.wikipedia.org/wiki/Eswatini
https://nl.wikipedia.org/wiki/Swaziland