### PR TITLE
feat: Allow alternative country name spellings via array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export type LocalizedCountryNames = {
-  [alpha2Key: string]: string
+  [alpha2Key: string]: string | string[]
 };
 
 export type LocaleData = {

--- a/index.js
+++ b/index.js
@@ -147,8 +147,9 @@ exports.toAlpha2 = toAlpha2;
  */
 exports.getName = function(code, lang) {
   try {
-    var d = registeredLocales[lang.toLowerCase()];
-    return d[toAlpha2(code)];
+    const codeMaps = registeredLocales[lang.toLowerCase()];
+    const names = codeMaps[toAlpha2(code)];
+    return Array.isArray(names) ? names[0] : names;
   } catch (err) {
     return undefined;
   }
@@ -172,12 +173,25 @@ exports.getNames = function(lang) {
  * @return ISO 3166-1 alpha-2 or undefined
  */
 exports.getAlpha2Code = function(name, lang) {
+  const normalizeString = (string) => string.toLowerCase();
+  const areSimilar = (a, b) => normalizeString(a) === normalizeString(b);
+
   try {
-    var p, codenames = registeredLocales[lang.toLowerCase()];
-    for (p in codenames) {
-      if (codenames.hasOwnProperty(p)) {
-        if (codenames[p].toLowerCase() === name.toLowerCase()) {
+    const codenames = registeredLocales[lang.toLowerCase()];
+    for (const p in codenames) {
+      if (!codenames.hasOwnProperty(p)) {
+        continue;
+      }
+      if (typeof codenames[p] === "string") {
+        if (areSimilar(codenames[p], name)) {
           return p;
+        }
+      }
+      if (Array.isArray(codenames[p])) {
+        for (const mappedName of codenames[p]) {
+          if (areSimilar(mappedName, name)) {
+            return p;
+          }
         }
       }
     }
@@ -193,12 +207,25 @@ exports.getAlpha2Code = function(name, lang) {
  * @return ISO 3166-1 alpha-2 or undefined
  */
 exports.getSimpleAlpha2Code = function(name, lang) {
+  const normalizeString = (string) => removeDiacritics(string.toLowerCase());
+  const areSimilar = (a, b) => normalizeString(a) === normalizeString(b);
+  
   try {
-    var p, codenames = registeredLocales[lang.toLowerCase()];
-    for (p in codenames) {
-      if (codenames.hasOwnProperty(p)) {
-        if (removeDiacritics(codenames[p].toLowerCase()) === removeDiacritics(name.toLowerCase())) {
+    const codenames = registeredLocales[lang.toLowerCase()];
+    for (const p in codenames) {
+      if (!codenames.hasOwnProperty(p)) {
+        continue;
+      }
+      if (typeof codenames[p] === "string") {
+        if (areSimilar(codenames[p], name)) {
           return p;
+        }
+      }
+      if (Array.isArray(codenames[p])) {
+        for (const mappedName of codenames[p]) {
+          if (areSimilar(mappedName, name)) {
+            return p;
+          }
         }
       }
     }

--- a/langs/pt.json
+++ b/langs/pt.json
@@ -69,7 +69,7 @@
     "SK": "Eslováquia",
     "SI": "Eslovênia",
     "ES": "Espanha",
-    "US": "Estados Unidos",
+    "US": ["Estados Unidos", "Estados Unidos da América"],
     "EE": "Estônia",
     "ET": "Etiópia",
     "FJ": "Fiji",

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -128,40 +128,46 @@ describe("i18n for iso 3166-1", function () {
     it("missing name", function() {
       assert.strictEqual(i18niso.getAlpha2Code("XXX", "de"), undefined);
     });
-    it("missing land", function() {
+    it("missing lang", function() {
       assert.strictEqual(i18niso.getAlpha2Code("Deutschland", "xx"), undefined);
     });
   });
   describe("getSimpleAlpha2Code", function() {
     it("works", function() {
-      assert.strictEqual(i18niso.getSimpleAlpha2Code("belgie", "nl"), 'BE');
-      assert.strictEqual(i18niso.getSimpleAlpha2Code("België", "nl"), 'BE');
+      assert.strictEqual(i18niso.getSimpleAlpha2Code("belgie", "nl"), "BE");
+      assert.strictEqual(i18niso.getSimpleAlpha2Code("België", "nl"), "BE");
     });
     it("missing name", function() {
       assert.strictEqual(i18niso.getSimpleAlpha2Code("XXX", "de"), undefined);
     });
-    it("missing land", function() {
+    it("missing lang", function() {
       assert.strictEqual(i18niso.getSimpleAlpha2Code("Deutschland", "xx"), undefined);
+    });
+    it("alternative name spellings", function() {
+      assert.strictEqual(i18niso.getSimpleAlpha2Code("Estados Unidos da América", "pt"), "US");
     });
   });
   describe("getAlpha3Code", function() {
     it("missing name", function() {
       assert.strictEqual(i18niso.getAlpha3Code("XXX", "de"), undefined);
     });
-    it("missing land", function() {
+    it("missing lang", function() {
       assert.strictEqual(i18niso.getAlpha3Code("Deutschland", "xx"), undefined);
     });
   });
   describe("getSimpleAlpha3Code", function() {
     it("works", function() {
-      assert.strictEqual(i18niso.getSimpleAlpha3Code("belgie", "nl"), 'BEL');
-      assert.strictEqual(i18niso.getSimpleAlpha3Code("België", "nl"), 'BEL');
+      assert.strictEqual(i18niso.getSimpleAlpha3Code("belgie", "nl"), "BEL");
+      assert.strictEqual(i18niso.getSimpleAlpha3Code("België", "nl"), "BEL");
     });
     it("missing name", function() {
       assert.strictEqual(i18niso.getSimpleAlpha3Code("XXX", "de"), undefined);
     });
-    it("missing land", function() {
+    it("missing lang", function() {
       assert.strictEqual(i18niso.getSimpleAlpha3Code("Deutschland", "xx"), undefined);
+    });
+    it("alternative name spellings", function() {
+      assert.strictEqual(i18niso.getSimpleAlpha3Code("Estados Unidos da América", "pt"), "USA");
     });
   });
   describe("isValid", function() {
@@ -386,6 +392,35 @@ describe("i18n for iso 3166-1", function () {
         });
       });
     });
+    
+    describe("pt", function () {
+      var lang = "pt";
+      describe("get Alpha-2 code", function() {
+        it("nameToAlpha2 Estados Unidos => US", function() {
+          assert.strictEqual(i18niso.getAlpha2Code("Estados Unidos", lang), "US");
+        });
+        it("nameToAlpha2 Estados Unidos da América => US", function() {
+          assert.strictEqual(i18niso.getAlpha2Code("Estados Unidos da América", lang), "US");
+        });
+      });
+      describe("get Alpha-3 code", function() {
+        it("nameToAlpha3 Estados Unidos => USA", function() {
+          assert.strictEqual(i18niso.getAlpha3Code("Estados Unidos", lang), "USA");
+        });
+        it("nameToAlpha3 Estados Unidos da América => USA", function() {
+          assert.strictEqual(i18niso.getAlpha3Code("Estados Unidos da América", lang), "USA");
+        });
+      });
+      describe("get name", function () {
+        it("for br => Brasil", function () {
+          assert.strictEqual(i18niso.getName("br", lang), "Brasil");
+        });
+        it("for us => Estados Unidos", function () {
+          assert.strictEqual(i18niso.getName("us", lang), "Estados Unidos");
+        });
+      });
+    });
+
     describe("unsupported language", function () {
       var lang = "unsupported";
       it("get name", function () {


### PR DESCRIPTION
Closes #174

I added test cases and updated the translation maps for the example in the issue.

```js
countries.getName("US", "pt") // Estados Unidos
countries.getAlpha2Code("Estados Unidos da América", "pt")) // US
countries.getAlpha2Code("Estados Unidos", "pt")) // US
countries.getSimpleAlpha2Code("Estados Unidos da America", "pt")) // US
```

---

While building this, I found the code a little hard to follow, using `var` everywhere. I changed this bits to use `const` instead (supported since Node 6)