### PR TITLE
chore: Drop Node 8, include Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
-sudo: false
+os: linux
+dist: xenial
 node_js:
-  - "8"
   - "10"
   - "12"
-  - "13"
+  - "13" # TODO: Remove this after 2020-06-01 (https://nodejs.org/en/about/releases/)
+  - "14"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "main": "entry-node",
   "browser": "index",
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Related to https://github.com/michaelwittig/node-i18n-iso-countries/issues/176

https://nodejs.org/en/about/releases/
- Node 8 is not maintained 
- Node 14 is in current development
- Node 13 will be deprecated on 2020-06-01

I also made sure we are following Travis' latest build config:
![image](https://user-images.githubusercontent.com/17657014/83199999-b53a3800-a118-11ea-88d2-9902062c2da0.png)
