### PR TITLE
fix: Update Portuguese name for Singapore

### DIFF
--- a/langs/pt.json
+++ b/langs/pt.json
@@ -46,7 +46,7 @@
     "CN": "China",
     "CY": "Chipre",
     "VA": "Cidade do Vaticano",
-    "SG": "Cingapura",
+    "SG": ["Singapura", "Cingapura"],
     "CO": "Colômbia",
     "KM": "Comores",
     "CG": "Congo - Brazzaville",


### PR DESCRIPTION
Since 2009, in Portuguese [Cingapura is wrong, Singapura is correct](https://duvidas.dicio.com.br/singapura-ou-cingapura/#:~:text=A%20forma%20correta%20de%20escrita,Ortogr%C3%A1fico%2C%20em%20janeiro%20de%202009.). But many places still write the country name with C.

So, I added the alternative name so people can still search it when writing with C.