### PR TITLE
Change name of Belarus in sv.json from Vitryssland to Belarus

### DIFF
--- a/langs/sv.json
+++ b/langs/sv.json
@@ -36,7 +36,7 @@
     "BT": "Bhutan",
     "BV": "Bouvetön",
     "BW": "Botswana",
-    "BY": "Vitryssland",
+    "BY": "Belarus",
     "BZ": "Belize",
     "CA": "Kanada",
     "CC": "Kokosöarna",


### PR DESCRIPTION
The Swedish Ministry of Foreign affairs changed from Vitryssland (literal translation of Belarus to swedish) to Belarus on 11th November 2019. Source: https://www.svt.se/nyheter/utrikes/regeringen-vitryssland-blir-belarus (SVT is swedish public service news channel)