### PR TITLE
ci: Node versions matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,21 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        node: ['10', '12', '14', '15']
+
+    name: Node ${{ matrix.node }} CI
 
     steps:
+      - uses: 'actions/checkout@v2'
 
-    - uses: 'actions/checkout@v2'
+      - uses: 'actions/setup-node@v1'
+        with:
+          node-version: ${{ matrix.node }}
 
-    - uses: 'actions/setup-node@v1'
-      with:
-        node-version: '12'
+      - name: install dependencies
+        run: npm ci
 
-    - name: install dependencies
-      run: npm ci
-
-    - name: run tests
-      run: npm test
+      - name: run tests
+        run: npm test


### PR DESCRIPTION
Sets up GitHub Actions to test every Pull Request and Push on multiple node versions:
- LTS: 10, 12, 14
- Current: 15

This is in preparation of the upcoming Typescript and infrastructure changes which might impact Node 10 and 15 users