### PR TITLE
fix: french Azerbaijan orthography

### DIFF
--- a/langs/fr.json
+++ b/langs/fr.json
@@ -15,7 +15,7 @@
     "AW": "Aruba",
     "AU": "Australie",
     "AT": "Autriche",
-    "AZ": "Azerbaidjan",
+    "AZ": "Azerbaïdjan",
     "BS": "Bahamas",
     "BH": "Bahrein",
     "BD": "Bangladesh",


### PR DESCRIPTION
Added missing diaeresis for french Azerbaijan orthography.