### PR TITLE
Change the name of Palestine to the official one

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -163,7 +163,7 @@
     "OM": "Oman",
     "PK": "Pakistan",
     "PW": "Palau",
-    "PS": "Palestinian Territory, Occupied",
+    "PS": ["State of Palestine", "Palestine"],
     "PA": "Panama",
     "PG": "Papua New Guinea",
     "PY": "Paraguay",


### PR DESCRIPTION
I changed the name of Palestine to the official one in accordance with
https://www.iso.org/obp/ui/#iso:code:3166:PS
or 
https://en.wikipedia.org/wiki/State_of_Palestine
