### PR TITLE
Fix Burma to Myanmar (Burma) - as no.json

### DIFF
--- a/langs/nb.json
+++ b/langs/nb.json
@@ -146,7 +146,7 @@
     "MH": "Marshalløyene",
     "MK": "Nord-Makedonia",
     "ML": "Mali",
-    "MM": "Burma",
+    "MM": "Myanmar (Burma)",
     "MN": "Mongolia",
     "MO": "Macao",
     "MP": "Nord-Marianene",


### PR DESCRIPTION
Burma should be Myanmar (Burma) in both nb.json and nn.json (Norwegian Bokmål and Norwegian Nynorsk) - as it is already in no.json.