### PR TITLE
Rename Swaziland to Eswatini (DE)

### DIFF
--- a/langs/de.json
+++ b/langs/de.json
@@ -216,7 +216,7 @@
     "SS": "Südsudan",
     "SR": "Suriname",
     "SJ": "Svalbard und Jan Mayen",
-    "SZ": "Swasiland",
+    "SZ": "Eswatini",
     "SY": "Syrien, Arabische Republik",
     "TJ": "Tadschikistan",
     "TZ": "Tansania, Vereinigte Republik",


### PR DESCRIPTION
Follow up to #170 and #171: Renaming also applies to German. Unfortunately, I don't know about any other languages.