### PR TITLE
Update nl.json

### DIFF
--- a/langs/nl.json
+++ b/langs/nl.json
@@ -100,7 +100,7 @@
     "HU": "Hongarije",
     "IS": "IJsland",
     "IN": "India",
-    "ID": "Indonesia",
+    "ID": "Indonesië",
     "IR": "Iran",
     "IQ": "Irak",
     "IE": "Ierland",


### PR DESCRIPTION
CHG: "Indonesia" is English and therefore incorrect. The correct Dutch name is "Indonesië"