### PR TITLE
Fix Taiwan official name

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -206,7 +206,7 @@
     "SE": "Sweden",
     "CH": "Switzerland",
     "SY": "Syrian Arab Republic",
-    "TW": ["Taiwan, Province of China", "Taiwan"],
+    "TW": ["Taiwan (Republic of China)", "Taiwan"],
     "TJ": "Tajikistan",
     "TZ": "Tanzania, United Republic of",
     "TH": "Thailand",


### PR DESCRIPTION
Renamed "Taiwan, Province of China" to "Taiwan (Republic of China)"

References: 
https://www.congress.gov/bill/117th-congress/senate-bill/1169/text
... diplomatic relations with the Republic of China (Taiwan) ...

https://www.irs.gov/businesses/international-businesses/attachment-for-the-republic-of-china-taiwan
https://en.wikipedia.org/wiki/Taiwan
https://www.nytimes.com/2021/01/11/world/asia/taiwan-new-passport.html
