### PR TITLE
Allow United States name

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -224,7 +224,7 @@
     "UA": "Ukraine",
     "AE": "United Arab Emirates",
     "GB": ["United Kingdom", "UK", "Great Britain"],
-    "US": ["United States of America", "USA"],
+    "US": ["United States of America","United States", "USA"],
     "UM": "United States Minor Outlying Islands",
     "UY": "Uruguay",
     "UZ": "Uzbekistan",

--- a/test/iso-i18n-countries.js
+++ b/test/iso-i18n-countries.js
@@ -267,6 +267,12 @@ describe("i18n for iso 3166-1", function () {
             "US"
           );
         });
+        it("nameToAlpha2 United States => US", function () {
+          assert.strictEqual(
+            i18niso.getAlpha2Code("United States", lang),
+            "US"
+          );
+        });
         it("nameToAlpha2 Brazil => BR", function () {
           assert.strictEqual(i18niso.getAlpha2Code("Brazil", lang), "BR");
         });


### PR DESCRIPTION
Get United State code with United States name. Google platform send United States instead of United States of America