### PR TITLE
en: Country name Iran corrected

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -101,7 +101,7 @@
     "IS": "Iceland",
     "IN": "India",
     "ID": "Indonesia",
-    "IR": "Iran, Islamic Republic of",
+    "IR": ["Iran", "Islamic Republic of Iran"],
     "IQ": "Iraq",
     "IE": "Ireland",
     "IL": "Israel",


### PR DESCRIPTION
There was a typo in the country name appearing at the signup form. Country name Iran was written as "Iran, Islamic Republic of" which is converted to "Islamic Republic of Iran".