### PR TITLE
feat: add alternative name for taiwan in IT

### DIFF
--- a/langs/it.json
+++ b/langs/it.json
@@ -228,7 +228,7 @@
     "TR": "Turchia",
     "TT": "Trinidad e Tobago",
     "TV": "Tuvalu",
-    "TW": "Repubblica di Cina",
+    "TW": ["Repubblica di Cina", "Taiwan"],
     "TZ": "Tanzania",
     "UA": "Ucraina",
     "UG": "Uganda",


### PR DESCRIPTION
This PR adds an alternative name for `TW` (Taiwan) to Italian language. Unlike most other languages that offer also/only "Taiwan" as a name, the only option so far in Italian was "Repubblica di Cina". 