### PR TITLE
Fix inconsistent USA alias

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -224,7 +224,7 @@
     "UA": "Ukraine",
     "AE": "United Arab Emirates",
     "GB": ["United Kingdom", "UK", "Great Britain"],
-    "US": ["United States of America","United States", "USA"],
+    "US": ["United States of America", "USA", "United States"],
     "UM": "United States Minor Outlying Islands",
     "UY": "Uruguay",
     "UZ": "Uzbekistan",


### PR DESCRIPTION
#261 makes "United States" as alias instead of previously "USA"  
It's inconsistent with "UK" and "Great Britain"

Either revert "USA" as alias (this PR),  
or make "Great Britain" as alias

*by alias, i mean the one selected with `{select: 'alias'}`