### PR TITLE
North Mecedonia Name Corrected

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -157,7 +157,7 @@
     "NG": "Nigeria",
     "NU": "Niue",
     "NF": "Norfolk Island",
-    "MK": "North Macedonia, Republic of",
+    "MK": ["The Republic of North Macedonia","North Macedonia"],
     "MP": "Northern Mariana Islands",
     "NO": "Norway",
     "OM": "Oman",


### PR DESCRIPTION
The name of the country North Macedonia was written as "North Macedonia, Republic of". Which was incorrect. I changed it to ["The Republic of North Macedonia","North Macedonia"]. Now we have 2 variants of it.