### PR TITLE
Iran name update in spanish language

### DIFF
--- a/langs/es.json
+++ b/langs/es.json
@@ -101,7 +101,7 @@
     "IS": "Islandia",
     "IN": "India",
     "ID": "Indonesia",
-    "IR": "Irán (República Islámica de)",
+    "IR": ["Irán", "República Islámica de Irán"],
     "IQ": "Iraq",
     "IE": "Irlanda",
     "IL": "Israel",


### PR DESCRIPTION
In Spanish language, country name Iran was written as "Irán (República Islámica de)". Which was incorrect. Now changed it to ["Irán", "República Islámica de Irán"]. Now we have 2 variants of it.