### PR TITLE
Country name Congo corrected

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -50,7 +50,7 @@
     "CO": "Colombia",
     "KM": "Comoros",
     "CG": "Congo",
-    "CD": "Congo, the Democratic Republic of the",
+    "CD": ["Congo", "Democratic Republic of the Congo"],
     "CK": "Cook Islands",
     "CR": "Costa Rica",
     "CI": "Cote D'Ivoire",


### PR DESCRIPTION
The name of the country Congo was written as "Congo, the Democratic Republic of the". Which was incorrect. I changed it to ["Congo", "Democratic Republic of the Congo"]. Now we have 2 variants of it.