### PR TITLE
Update lt.json

### DIFF
--- a/langs/lt.json
+++ b/langs/lt.json
@@ -79,7 +79,7 @@
     "GA": "Gabonas",
     "GB": "Jungtinė Karalystė",
     "GD": "Grenada",
-    "GE": "Gruzija",
+    "GE": "Sakartvelas",
     "GF": "Prancūzijos Gviana",
     "GG": "Gernsis",
     "GH": "Gana",

--- a/langs/lt.json
+++ b/langs/lt.json
@@ -79,7 +79,7 @@
     "GA": "Gabonas",
     "GB": "Jungtinė Karalystė",
     "GD": "Grenada",
-    "GE": "Sakartvelas",
+    "GE":  ["Sakartvelas", "Gruzija"],
     "GF": "Prancūzijos Gviana",
     "GG": "Gernsis",
     "GH": "Gana",


### PR DESCRIPTION
Lithuania has changed it's official name for Georgia (Gruzija) to Sakartvelo (Sakartvelas)
Source from national Lithuanian language commission: http://www.vlkk.lt/konsultacijos/4182-gruzija