### PR TITLE
Add alternative English name for Czech Republic

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -57,7 +57,7 @@
     "HR": "Croatia",
     "CU": "Cuba",
     "CY": "Cyprus",
-    "CZ": "Czech Republic",
+    "CZ": ["Czech Republic", "Czechia"],
     "DK": "Denmark",
     "DJ": "Djibouti",
     "DM": "Dominica",


### PR DESCRIPTION
Add Czechia as an alternative English name for Czech Republic