### PR TITLE
Added back "turkey"

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -216,7 +216,7 @@
     "TO": "Tonga",
     "TT": "Trinidad and Tobago",
     "TN": "Tunisia",
-    "TR": "Türkiye",
+    "TR": ["Türkiye","Turkey"],
     "TM": "Turkmenistan",
     "TC": "Turks and Caicos Islands",
     "TV": "Tuvalu",


### PR DESCRIPTION
Though the country changed it's official name i think it is appropriate to keep in "turkey" as it is commonly used by users