### PR TITLE
update name of Kyrgyzstan and Taiwan

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -206,7 +206,7 @@
     "SE": "Sweden",
     "CH": "Switzerland",
     "SY": "Syrian Arab Republic",
-    "TW": ["Taiwan, Province of China", "Taiwan"],
+    "TW": "Taiwan",
     "TJ": "Tajikistan",
     "TZ": ["United Republic of Tanzania", "Tanzania"],
     "TH": "Thailand",

--- a/langs/en.json
+++ b/langs/en.json
@@ -115,7 +115,7 @@
     "KP": "North Korea",
     "KR": "South Korea",
     "KW": "Kuwait",
-    "KG": "Kyrgyzstan",
+    "KG": ["Kyrgyz Republic", "Kyrgyzstan"],
     "LA": "Lao People's Democratic Republic",
     "LV": "Latvia",
     "LB": "Lebanon",


### PR DESCRIPTION
Kyrgyzstan recently started trying to get rid of the Kyrgyzstan name and use Kyrgyz Republic by default. Taiwan is a separate country and even non-English translations don't mention "China" in the name of Taiwan.