### PR TITLE
fix: undefined as return type is missing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,12 +18,12 @@ export type LocaleData = {
 
 
 export function registerLocale(localeData: LocaleData): void;
-export function alpha2ToAlpha3(alpha2: string | Alpha2Code): string;
-export function alpha2ToNumeric(alpha2: string | Alpha2Code): string;
-export function alpha3ToAlpha2(alpha3: string | Alpha3Code): string;
-export function alpha3ToNumeric(alpha3: string | Alpha3Code): string;
-export function numericToAlpha2(numeric: number | string): string;
-export function numericToAlpha3(numeric: number | string): string;
+export function alpha2ToAlpha3(alpha2: string | Alpha2Code): string | undefined;
+export function alpha2ToNumeric(alpha2: string | Alpha2Code): string | undefined;
+export function alpha3ToAlpha2(alpha3: string | Alpha3Code): string | undefined;
+export function alpha3ToNumeric(alpha3: string | Alpha3Code): string | undefined;
+export function numericToAlpha2(numeric: number | string): string | undefined;
+export function numericToAlpha3(numeric: number | string): string | undefined;
 
 /**
  * Returns object map where key is alpha 2 code and value is alpha 3 code
@@ -47,7 +47,7 @@ export function getNumericCodes(): { [numericKey: string]: string };
 export function getName(
   countryCode: string | number | Alpha2Code | Alpha3Code,
   lang: string
-): string;
+): string | undefined;
 
 /**
  * @param countryCode  Alpha2 or Alpha3 or Numeric
@@ -58,7 +58,7 @@ export function getName<T extends GetNameOptions>(
   countryCode: string | number | Alpha2Code | Alpha3Code,
   lang: string,
   options: T
-): CountryName<T>;
+): CountryName<T> | undefined;
 
 /**
  * @param lang    ISO 639-1 format string
@@ -74,18 +74,18 @@ export function getNames<T extends GetNameOptions>(
   options: T
 ): LocalizedCountryNames<T>;
 
-export function getAlpha2Code(name: string, lang: string): string;
-export function getSimpleAlpha2Code(name: string, lang: string): string;
-export function getAlpha3Code(name: string, lang: string): string;
-export function getSimpleAlpha3Code(name: string, lang: string): string;
+export function getAlpha2Code(name: string, lang: string): string | undefined;
+export function getSimpleAlpha2Code(name: string, lang: string): string | undefined;
+export function getAlpha3Code(name: string, lang: string): string | undefined;
+export function getSimpleAlpha3Code(name: string, lang: string): string | undefined;
 export function langs(): string[];
 export function getSupportedLanguages(): string[];
 export function toAlpha3(
   alpha2orNumeric: number | string | Alpha2Code
-): string;
+): string | undefined;
 export function toAlpha2(
   alpha3orNumeric: number | string | Alpha3Code
-): string;
+): string | undefined;
 export function isValid(alpha2orAlpha3orNumeric: string | number): boolean;
 
 


### PR DESCRIPTION
Several functions return `undefined`, but they are defined as returning `string` always.

This tries to fix all the use cases I found, but there might be more.

Here are some examples:
https://github.com/michaelwittig/node-i18n-iso-countries/blob/cf01cdadefc7758dcf9faf50186200cd8720a700/index.js#L227
https://github.com/michaelwittig/node-i18n-iso-countries/blob/cf01cdadefc7758dcf9faf50186200cd8720a700/index.js#L227