### PR TITLE
feat(de): add Hong Kong alias

### DIFF
--- a/langs/de.json
+++ b/langs/de.json
@@ -83,7 +83,7 @@
     "HT": "Haiti",
     "HM": "Heard und McDonaldinseln",
     "HN": "Honduras",
-    "HK": "Hongkong",
+    "HK": ["Hongkong", "Hong Kong"],
     "IN": "Indien",
     "ID": "Indonesien",
     "IM": "Insel Man",


### PR DESCRIPTION
This PR adds an alias, `Hong Kong`, for the German language.

Closes #196 