### PR TITLE
Fix translate en/tw

### DIFF
--- a/langs/en.json
+++ b/langs/en.json
@@ -206,7 +206,7 @@
     "SE": "Sweden",
     "CH": "Switzerland",
     "SY": "Syrian Arab Republic",
-    "TW": ["Taiwan, Province of China", "Taiwan"],
+    "TW": "Taiwan",
     "TJ": "Tajikistan",
     "TZ": ["United Republic of Tanzania", "Tanzania"],
     "TH": "Thailand",


### PR DESCRIPTION
Fix Taiwan country name, due to political conflicts between them.
